### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/examples/project1/build.py
+++ b/examples/project1/build.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env pyrate
 
 default_context.basepath = 'build'
-assert(find_internal('libfoo') == None)
+assert(find_internal('libfoo') is None)
 include('foo', inherit = True)
 libfoo = find_internal('libfoo')
 install(executable('example02.bin', [match('test.cpp'), libfoo]))

--- a/pyrate.py
+++ b/pyrate.py
@@ -1321,9 +1321,9 @@ def run_build_file(bfn, ctx, user_env):
 				exec_line = None
 				exloc = traceback.extract_tb(sys.exc_info()[2])
 				for idx, entry in enumerate(exloc):
-					if entry[3] == None:
+					if entry[3] is None:
 						exec_line = idx
-				if exec_line != None:
+				if exec_line is not None:
 					exloc = [(bfn, exloc[exec_line][1], '', linecache.getline(bfn, exloc[exec_line][1]))] + exloc[idx:]
 				sys.stderr.write('Error while processing %s\n' % os.path.abspath(bfn))
 				sys.stderr.write(str.join('', traceback.format_list(exloc)))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:pyrate-build:pyrate-build?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:pyrate-build:pyrate-build?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
